### PR TITLE
Return FilterReply.NEUTRAL instead of ACCEPT.

### DIFF
--- a/src/main/java/org/springframework/metrics/instrument/binder/LogbackMetrics.java
+++ b/src/main/java/org/springframework/metrics/instrument/binder/LogbackMetrics.java
@@ -68,6 +68,6 @@ class MetricsTurboFilter extends TurboFilter {
                 break;
         }
 
-        return FilterReply.ACCEPT;
+        return FilterReply.NEUTRAL;
     }
 }


### PR DESCRIPTION
Returning NEUTRAL let the other filters decide what to do. Otherwise
logging configuration is not obeyed and everything is logged.