### PR TITLE
Add MeterReporter that allows registering customer groupings of metrics

### DIFF
--- a/src/main/java/org/springframework/metrics/instrument/Meter.java
+++ b/src/main/java/org/springframework/metrics/instrument/Meter.java
@@ -20,4 +20,12 @@ package org.springframework.metrics.instrument;
  */
 public interface Meter {
     String getName();
+
+    enum Type {
+        COUNTER,
+        GAUGE,
+        DISTRIBUTION_SUMMARY,
+        LONG_TASK_TIMER,
+        TIMER
+    }
 }

--- a/src/main/java/org/springframework/metrics/instrument/MeterRegistry.java
+++ b/src/main/java/org/springframework/metrics/instrument/MeterRegistry.java
@@ -501,4 +501,6 @@ public interface MeterRegistry {
     default ExecutorService monitor(String name, ExecutorService executor) {
         return monitor(name, emptyList(), executor);
     }
+
+    MeterRegistry monitor(MeterReporter meterReporter);
 }

--- a/src/main/java/org/springframework/metrics/instrument/MeterReporter.java
+++ b/src/main/java/org/springframework/metrics/instrument/MeterReporter.java
@@ -1,0 +1,15 @@
+package org.springframework.metrics.instrument;
+
+import org.springframework.metrics.instrument.binder.MeterBinder;
+
+import java.util.List;
+
+abstract public class MeterReporter implements MeterBinder{
+
+  @Override
+  public void bindTo(MeterRegistry registry) {
+    registry.monitor(this);
+  }
+
+  abstract public List<MeterSamples> report();
+}

--- a/src/main/java/org/springframework/metrics/instrument/MeterReporter.java
+++ b/src/main/java/org/springframework/metrics/instrument/MeterReporter.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument;
 
 import org.springframework.metrics.instrument.binder.MeterBinder;

--- a/src/main/java/org/springframework/metrics/instrument/MeterSamples.java
+++ b/src/main/java/org/springframework/metrics/instrument/MeterSamples.java
@@ -1,0 +1,62 @@
+package org.springframework.metrics.instrument;
+
+import org.springframework.metrics.instrument.internal.MeterId;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.metrics.instrument.internal.MeterId.*;
+
+public class MeterSamples {
+  private final String name;
+  private final Meter.Type type;
+  private final List<Sample> samples = new ArrayList<>();
+
+  public MeterSamples(String name, Meter.Type type) {
+    this.name = name;
+    this.type = type;
+  }
+
+  public MeterSamples(String name, Meter.Type type, Tag tag, Double value){
+    this(name, type);
+    samples.add(new Sample(id(name, tag), value));
+  }
+
+
+  public MeterSamples(String name, Meter.Type type, List<Tag> tags, Double value){
+    this(name, type);
+    samples.add(new Sample(id(name, tags), value));
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public Meter.Type getType() {
+    return type;
+  }
+
+  public List<Sample> getSamples() {
+    return samples;
+  }
+
+  public static class Sample {
+    private final MeterId id;
+    private final Double value;
+
+    public Sample(MeterId id, Double value) {
+      this.id = id;
+      this.value = value;
+    }
+
+    public MeterId getId() {
+      return id;
+    }
+
+    public Double getValue() {
+      return value;
+    }
+  }
+
+
+}

--- a/src/main/java/org/springframework/metrics/instrument/MeterSamples.java
+++ b/src/main/java/org/springframework/metrics/instrument/MeterSamples.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument;
 
 import org.springframework.metrics.instrument.internal.MeterId;

--- a/src/main/java/org/springframework/metrics/instrument/internal/MapAccess.java
+++ b/src/main/java/org/springframework/metrics/instrument/internal/MapAccess.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.internal;
 
 import java.util.concurrent.ConcurrentMap;

--- a/src/main/java/org/springframework/metrics/instrument/internal/MeterId.java
+++ b/src/main/java/org/springframework/metrics/instrument/internal/MeterId.java
@@ -35,6 +35,10 @@ public class MeterId {
         return new MeterId(name, tags);
     }
 
+    public static MeterId id(String name, Tag... tags) {
+        return new MeterId(name, Arrays.asList(tags));
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterRegistry.java
+++ b/src/main/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterRegistry.java
@@ -137,7 +137,13 @@ public class PrometheusMeterRegistry extends AbstractMeterRegistry {
         return obj;
     }
 
-    /**
+  @Override
+  public MeterRegistry monitor(MeterReporter meterReporter) {
+    registry.register(new PrometheusMeterReporterCollector(meterReporter));
+    return this;
+  }
+
+  /**
      * @return The underlying Prometheus {@link CollectorRegistry}.
      */
     public CollectorRegistry getPrometheusRegistry() {

--- a/src/main/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollector.java
+++ b/src/main/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollector.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.prometheus;
 
 import io.prometheus.client.Collector;

--- a/src/main/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollector.java
+++ b/src/main/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollector.java
@@ -1,0 +1,65 @@
+package org.springframework.metrics.instrument.prometheus;
+
+import io.prometheus.client.Collector;
+import org.springframework.metrics.instrument.Meter;
+import org.springframework.metrics.instrument.MeterReporter;
+import org.springframework.metrics.instrument.MeterSamples;
+import org.springframework.metrics.instrument.Tag;
+import org.springframework.metrics.instrument.internal.MeterId;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PrometheusMeterReporterCollector extends Collector {
+  private final MeterReporter meterReporter;
+
+  public PrometheusMeterReporterCollector(MeterReporter meterReporter) {
+    this.meterReporter = meterReporter;
+  }
+
+  @Override
+  public List<MetricFamilySamples> collect() {
+    List<MetricFamilySamples> metrics = new ArrayList<>();
+    for(MeterSamples sample: meterReporter.report()) {
+      Type type = convertType(sample.getType());
+      MetricFamilySamples familySamples = new MetricFamilySamples(sample.getName(), type," ",
+              convertSamples(sample.getSamples()));
+      metrics.add(familySamples);
+    }
+    return metrics;
+  }
+
+  private List<MetricFamilySamples.Sample> convertSamples(List<MeterSamples.Sample> samples) {
+    return samples.stream().map(sample -> {
+      MeterId id = sample.getId();
+      List<String> tagKeys = Arrays.stream(id.getTags()).map(Tag::getKey).collect(Collectors.toList());
+      List<String> tagValues = Arrays.stream(id.getTags()).map(Tag::getValue).collect(Collectors.toList());
+
+      return new MetricFamilySamples.Sample(id.getName(), tagKeys, tagValues, sample.getValue());
+    }).collect(Collectors.toList());
+  }
+
+  private Type convertType(Meter.Type type) {
+    Type result = null;
+    switch (type) {
+      case COUNTER:
+        result = Type.COUNTER;
+        break;
+      case GAUGE:
+        result = Type.GAUGE;
+        break;
+      case DISTRIBUTION_SUMMARY:
+        result = Type.SUMMARY;
+        break;
+      case LONG_TASK_TIMER:
+        result = Type.SUMMARY;
+        break;
+      case TIMER:
+        result = Type.SUMMARY;
+        break;
+    }
+    return result;
+  }
+}

--- a/src/main/java/org/springframework/metrics/instrument/simple/SimpleMeterRegistry.java
+++ b/src/main/java/org/springframework/metrics/instrument/simple/SimpleMeterRegistry.java
@@ -85,6 +85,11 @@ public class SimpleMeterRegistry extends AbstractMeterRegistry {
     }
 
     @Override
+    public MeterRegistry monitor(MeterReporter meterReporter) {
+        return null;
+    }
+
+    @Override
     public Collection<Meter> getMeters() {
         return meterMap.values();
     }

--- a/src/main/java/org/springframework/metrics/instrument/spectator/SpectatorMeterRegistry.java
+++ b/src/main/java/org/springframework/metrics/instrument/spectator/SpectatorMeterRegistry.java
@@ -138,6 +138,11 @@ public class SpectatorMeterRegistry extends AbstractMeterRegistry {
         return obj;
     }
 
+    @Override
+    public MeterRegistry monitor(MeterReporter meterReporter) {
+        throw new UnsupportedOperationException("TODO: Implement");
+    }
+
     /**
      * @return The underlying Spectator {@link Registry}.
      */

--- a/src/main/java/org/springframework/metrics/instrument/stats/CumulativeHistogram.java
+++ b/src/main/java/org/springframework/metrics/instrument/stats/CumulativeHistogram.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.stats;
 
 import java.util.Collections;

--- a/src/main/java/org/springframework/metrics/instrument/stats/Histogram.java
+++ b/src/main/java/org/springframework/metrics/instrument/stats/Histogram.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.stats;
 
 import java.util.Set;

--- a/src/main/java/org/springframework/metrics/instrument/stats/NormalHistogram.java
+++ b/src/main/java/org/springframework/metrics/instrument/stats/NormalHistogram.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.stats;
 
 import java.util.Map;

--- a/src/test/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollectorTest.java
+++ b/src/test/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollectorTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.prometheus;
 
 import io.prometheus.client.Collector;

--- a/src/test/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollectorTest.java
+++ b/src/test/java/org/springframework/metrics/instrument/prometheus/PrometheusMeterReporterCollectorTest.java
@@ -1,0 +1,39 @@
+package org.springframework.metrics.instrument.prometheus;
+
+import io.prometheus.client.Collector;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.metrics.instrument.Meter;
+import org.springframework.metrics.instrument.MeterReporter;
+import org.springframework.metrics.instrument.MeterSamples;
+import org.springframework.metrics.instrument.Tags;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class PrometheusMeterReporterCollectorTest {
+  @Test
+  @DisplayName("collector will convert Meters to Prometheus family samples")
+  void collect() {
+    PrometheusMeterReporterCollector collector = new PrometheusMeterReporterCollector(new MeterReporter() {
+      @Override
+      public List<MeterSamples> report() {
+        List<MeterSamples> meters = new ArrayList<>();
+        meters.add(new MeterSamples("counter_example", Meter.Type.COUNTER, Tags.tagList("tagKey", "tagValue"), 1.0));
+        meters.add(new MeterSamples("gauge_example", Meter.Type.GAUGE, Tags.tagList("tagKey", "tagValue"), 1.0));
+        meters.add(new MeterSamples("summary_example", Meter.Type.TIMER, Tags.tagList("tagKey", "tagValue"), 1.0));
+        meters.add(new MeterSamples("summary_long_timer_example", Meter.Type.LONG_TASK_TIMER, Tags.tagList("tagKey", "tagValue"), 1.0));
+        return meters;
+      }
+    });
+
+    List<Collector.MetricFamilySamples> results = collector.collect();
+    assertThat(results).hasSize(4);
+  }
+
+
+
+}

--- a/src/test/java/org/springframework/metrics/instrument/stats/CumulativeHistogramTest.java
+++ b/src/test/java/org/springframework/metrics/instrument/stats/CumulativeHistogramTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.stats;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/springframework/metrics/instrument/stats/NormalHistogramTest.java
+++ b/src/test/java/org/springframework/metrics/instrument/stats/NormalHistogramTest.java
@@ -1,3 +1,18 @@
+/**
+ * Copyright 2017 Pivotal Software, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.metrics.instrument.stats;
 
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
Initial pass at `MeterReporter` implementation. I wanted some initial feedback before proceeding too far.

The test at the end demonstrates the usage pattern best. 