### PR TITLE
Fix closing code brackets for Prometheus documentation

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -554,6 +554,7 @@ Add `@EnablePrometheusMetrics` to your configuration.
 @EnablePrometheusMetrics
 public class MyApp {
 }
+```
 
 Then inject `MeterRegistry` wherever you need to create a timer, gauge, counter, or summary. Where supported,
 you may also use the `@Timed` annotation, which eliminates the need to inject a `MeterRegistry` in certain


### PR DESCRIPTION
This PR adds closing code brackets to a code example under the Prometheus section in the documentation which broke asciidoc rendering.